### PR TITLE
Q4の解答を修正

### DIFF
--- a/Question_01_10/answers_cpp/answer_4.cpp
+++ b/Question_01_10/answers_cpp/answer_4.cpp
@@ -17,8 +17,8 @@ cv::Mat BGR2GRAY(cv::Mat img){
     for (int x = 0; x < width; x++){
       // BGR -> Gray
       out.at<uchar>(y, x) = 0.2126 * (float)img.at<cv::Vec3b>(y, x)[2] \
-        + 0.7152 * (float)img.at<cv::Vec3b>(y, x)[1] \
-        + 0.0722 * (float)img.at<cv::Vec3b>(y, x)[0];
+                          + 0.7152 * (float)img.at<cv::Vec3b>(y, x)[1] \
+                          + 0.0722 * (float)img.at<cv::Vec3b>(y, x)[0];
     }
   }
 
@@ -31,8 +31,8 @@ cv::Mat Binarize_Otsu(cv::Mat gray){
   int height = gray.rows;
 
   // determine threshold
-  double w0 = 0, w1 = 0;
-  double m0 = 0, m1 = 0;
+  double w0, w1;
+  double m0, m1;
   double max_sb = 0, sb = 0;
   int th = 0;
   int val;
@@ -46,8 +46,7 @@ cv::Mat Binarize_Otsu(cv::Mat gray){
     for (int y = 0; y < height; y++){
       for (int x = 0; x < width; x++){
         val = (int)(gray.at<uchar>(y, x));
-
-        if (val < t){
+        if (val <= t){
           w0++;
           m0 += val;
         } else {
@@ -83,7 +82,6 @@ cv::Mat Binarize_Otsu(cv::Mat gray){
       } else {
         out.at<uchar>(y, x) = 0;
       }
-    
     }
   }
 

--- a/Question_01_10/answers_py/answer_4.py
+++ b/Question_01_10/answers_py/answer_4.py
@@ -14,9 +14,10 @@ def BGR2GRAY(img):
 
 	return out
 
-# Otsu Binalization
+# Otsu Binarization
 def otsu_binarization(img, th=128):
-	imax_sigma = 0
+	H, W = img.shape
+	max_sigma = 0
 	max_t = 0
 
 	# determine threshold
@@ -35,8 +36,8 @@ def otsu_binarization(img, th=128):
 	# Binarization
 	print("threshold >>", max_t)
 	th = max_t
-	out[out < th] = 0
-	out[out >= th] = 255
+	out[out <= th] = 0
+	out[out > th] = 255
 
 	return out
 
@@ -49,7 +50,7 @@ img = cv2.imread("imori.jpg").astype(np.float32)
 out = BGR2GRAY(img)
 
 # Otsu's binarization
-out = otsu_binalization(out)
+out = otsu_binarization(out)
 
 # Save result
 cv2.imwrite("out.jpg", out)

--- a/Question_01_10/answers_py/answer_4.py
+++ b/Question_01_10/answers_py/answer_4.py
@@ -21,7 +21,7 @@ def otsu_binarization(img, th=128):
 	max_t = 0
 
 	# determine threshold
-	for _t in range(1, 255):
+	for _t in range(255):
 		v0 = out[np.where(out < _t)]
 		m0 = np.mean(v0) if len(v0) > 0 else 0.
 		w0 = len(v0) / (H * W)


### PR DESCRIPTION
> 私は日本語が下手なので、もし理解しにくい場合は、以下「English Ver.」を参照してください。

こんにちは、Question 4の解答にいくつかの誤りがあることに気付きました。
C++で再現するには、[L102](https://github.com/ryoppippi/Gasyori100knock/blob/master/Question_01_10/answers_cpp/answer_4.cpp#L102)を
```
  cv::Mat out = Binarize_Otsu(gray);
```
から
```
  cv::Mat gray(200, 200, CV_8UC1, cv::Scalar(255));
  cv::Rect rect(95, 95, 10, 10);
  cv::Mat square = gray(rect);
  square.setTo(cv::Scalar(254));
```
に置き換えることができます。

[期待される結果](https://github.com/NekoAsakura/Gasyori100knock/blob/notes/Question_01_10/answers_cpp/expected.jpg)は、白いキャンバスに10ピクセルの黒い四角が表示されるはずですが、完全に黒い画像になっています。

ちなみに、Pythonの解答もいくつかの問題がありました。
- `otsu_binarization` が `otsu_binalization`と誤記されている（ｗｗ）
- HとWが初期化されていない
- 変数は`imax_sigma`が設定されているが、`max_sigma`が呼び出されている。
- `< th` と `>= th` は `<= th` と `> th` にする必要があります。

======English Ver.======
Hello, I noticed that there are some errors in the answer for Question 4.
To reproduce it in C++ code, you can replace [L102](https://github.com/ryoppippi/Gasyori100knock/blob/master/Question_01_10/answers_cpp/answer_4.cpp#L102)
```
  cv::Mat out = Binarize_Otsu(gray);
```
with
```
  cv::Mat gray(200, 200, CV_8UC1, cv::Scalar(255));
  cv::Rect rect(95, 95, 10, 10);
  cv::Mat square = gray(rect);
  square.setTo(cv::Scalar(254));
```
The [expected return](https://github.com/NekoAsakura/Gasyori100knock/blob/notes/Question_01_10/answers_cpp/expected.jpg) should be a 10-pixel black square on a white canvas rather than a completely black image.

By the way, I also found some issues in the Python script, such as
- misspelling of `otsu_binarization` as `otsu_binalization`
- height and width not being initialized with `H, W = img.shape`
- `imax_sigma` assigned but `max_sigma` being called later
- wrong implement with `< th` and range